### PR TITLE
Add environment tip about long output lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,17 @@ This is a commercial application. All rights reserved.
 
 This is a commercial product. For feature requests or bug reports, please contact the development team.
 
+## Environment Tips
+
+When working in Codex the shell limits each line of output. If a command prints
+over 1600 bytes in a single line, the session closes. Use tools such as
+
+```bash
+grep -nE 'PATTERN' FILE | cut -c1-200
+```
+
+to keep line lengths short when inspecting large files.
+
 ---
 
 **Vino Tracker** - Professional wine sales management made simple.


### PR DESCRIPTION
## Summary
- document how to avoid long line errors in Codex shell

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and network is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68766bec7e688321b369281d38dbf653